### PR TITLE
Containerd mirror

### DIFF
--- a/images/capi/ansible/roles/stfc_customisations/defaults/main.yml
+++ b/images/capi/ansible/roles/stfc_customisations/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+docker_io_mirror: "https://dockerhub.stfc.ac.uk"

--- a/images/capi/ansible/roles/stfc_customisations/files/cri-registry.toml
+++ b/images/capi/ansible/roles/stfc_customisations/files/cri-registry.toml
@@ -1,0 +1,2 @@
+[plugins."io.containerd.grpc.v1.cri".registry]
+   config_path = "/etc/containerd/certs.d"

--- a/images/capi/ansible/roles/stfc_customisations/tasks/main.yml
+++ b/images/capi/ansible/roles/stfc_customisations/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Create containerd configuration directory
+  file:
+    path: /etc/containerd/conf.d/
+    state: directory
+    recurse: yes
+
+- name: Create containerd certs directory for docker.io
+  file:
+    path: /etc/containerd/certs.d/docker.io
+    state: directory
+    recurse: yes
+
+- name: Copy config to point CRI to /etc/containerd/certs.d
+  copy:
+    src: cri-registry.toml
+    dest: /etc/containerd/conf.d/cri-registry.toml
+    mode: 0644
+
+- name: Copy config for docker.io mirror
+  template:
+    src: dockerhub-hosts.toml
+    dest: /etc/containerd/certs.d/docker.io/hosts.toml
+    mode: 0644

--- a/images/capi/ansible/roles/stfc_customisations/templates/dockerhub-hosts.toml
+++ b/images/capi/ansible/roles/stfc_customisations/templates/dockerhub-hosts.toml
@@ -1,0 +1,4 @@
+server = "{{ docker_io_mirror }}"
+
+[host."{{ docker_io_mirror }}"]
+  capabilities = ["pull", "resolve"]

--- a/images/capi/packer/config/stfc.json
+++ b/images/capi/packer/config/stfc.json
@@ -1,0 +1,3 @@
+{
+    "firstboot_custom_roles_pre": "stfc_customisations"
+}

--- a/images/capi/packer/config/stfc.json
+++ b/images/capi/packer/config/stfc.json
@@ -1,3 +1,4 @@
 {
+    "cpus": "8",
     "firstboot_custom_roles_pre": "stfc_customisations"
 }


### PR DESCRIPTION
Add configuration bespoke to STFC:

- Use our Docker caching layer instead of Dockerhub
- Increase the number of cores used for creating images