### PR TITLE
Merge CRI Registries into config.toml

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -11,6 +11,11 @@ imports = ["/etc/containerd/conf.d/*.toml"]
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pause_image }}"
+
+# STFC Dockerhub Mirror
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
+
 {% if kubernetes_semver is version('v1.21.0', '>=') %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"

--- a/images/capi/ansible/roles/stfc_customisations/files/cri-registry.toml
+++ b/images/capi/ansible/roles/stfc_customisations/files/cri-registry.toml
@@ -1,2 +1,0 @@
-[plugins."io.containerd.grpc.v1.cri".registry]
-   config_path = "/etc/containerd/certs.d"

--- a/images/capi/ansible/roles/stfc_customisations/tasks/main.yml
+++ b/images/capi/ansible/roles/stfc_customisations/tasks/main.yml
@@ -1,21 +1,9 @@
 ---
-- name: Create containerd configuration directory
-  file:
-    path: /etc/containerd/conf.d/
-    state: directory
-    recurse: yes
-
 - name: Create containerd certs directory for docker.io
   file:
     path: /etc/containerd/certs.d/docker.io
     state: directory
     recurse: yes
-
-- name: Copy config to point CRI to /etc/containerd/certs.d
-  copy:
-    src: cri-registry.toml
-    dest: /etc/containerd/conf.d/cri-registry.toml
-    mode: 0644
 
 - name: Copy config for docker.io mirror
   template:


### PR DESCRIPTION
What this PR does / why we need it:

Because of https://github.com/containerd/containerd/issues/5837 we're
not able to seperate out the registries directive whilst using the
Nvidia runtime.

To workaround this we will edit the original config.toml so all
definitions are in-line. Even though this will likely result in
conflicts with upstream in the future.