### PR TITLE
Fix import from folder preventing key merge of Nvidia

### DIFF
--- a/images/capi/ansible/roles/stfc_customisations/tasks/main.yml
+++ b/images/capi/ansible/roles/stfc_customisations/tasks/main.yml
@@ -11,6 +11,11 @@
     state: directory
     recurse: yes
 
+- name: Create a file to hold the Nvidia container config
+  file:
+    path: /etc/containerd/conf.d/nvidia.toml
+    state: touch
+
 - name: Copy config to point CRI to /etc/containerd/certs.d
   copy:
     src: cri-registry.toml


### PR DESCRIPTION
Use `import` statement to load the nvidia toolkit runtime based on the StackHPC approach
This was preventing the Nvidia runtime starting